### PR TITLE
Add current user to docker group (Debian)

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -47,6 +47,12 @@
     apt: name=criu state=present
     when: docker_install_criu and ansible_distribution_major_version == "16"
 
+  - name: Add current user to docker group
+    user:
+      name: "{{ ansible_user }}"
+      groups: docker
+      append: yes
+
   when: not docker_containerd_only | bool
 
 - block:


### PR DESCRIPTION
# Docker Group Permission Fix

The Ansible role automatically adds the default user to the `docker` group to avoid requiring `sudo` for Docker commands.

## Problem
Without this fix, users get permission errors:

```bash
$ docker images
permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock

$ groups
cloudadm
```

## Solution
The role adds the deployment user to the docker group:

```yaml
- name: Add current user to docker group
  user:
    name: "{{ ansible_user }}"
    groups: docker
    append: yes
```

⚠️ **Security Note**: This grants root-equivalent privileges.

## After Fix
```bash
$ docker images
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE

$ groups
cloudadm docker
```

## Troubleshooting
- **Manual fix**: `sudo usermod -aG docker $USER`